### PR TITLE
fix null players bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - 2021-08-26
+
+### Fixed
+
+- Some league rosters return null for the players, which breaks power rankings and the rosters page
+    - Bug reported in [issue #49](https://github.com/nmelhado/league-page/issues/49)
+    - For rosters, only compute the bench if the players field is valid
+    - For power rankings, skip teams with no players (if no teams have players, don't display the graph)
+
 ## [1.0.4] - 2021-08-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "league-page",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/nmelhado/league-page#readme",
   "author": {
     "name": "Nicholas Melhado",

--- a/src/lib/PowerRankings/PowerRankingsDisplay.svelte
+++ b/src/lib/PowerRankings/PowerRankingsDisplay.svelte
@@ -24,7 +24,14 @@
 
     let max = 0;
 
+    let validGraph = false;
+
     for(const roster of rosters) {
+        // make sure the roster has players on it
+        if(!roster.players) continue;
+        // if at least one team has players, create the graph
+        validGraph = true;
+
         const rosterPlayers = [];
 
         for(const rosterPlayer of roster.players) {
@@ -96,6 +103,8 @@
     }
 </style>
 
-<div class="enclosure" bind:this={el}>
-    <BarChart {maxWidth} {graphs} bind:curGraph={curGraph} />
-</div>
+{#if validGraph}
+    <div class="enclosure" bind:this={el}>
+        <BarChart {maxWidth} {graphs} bind:curGraph={curGraph} />
+    </div>
+{/if}

--- a/src/lib/Rosters/Roster.svelte
+++ b/src/lib/Rosters/Roster.svelte
@@ -70,7 +70,10 @@
 	}
 
 	$: finalStarters = digestData(roster.starters, true);
-	$: finalBench = digestData(roster.players);
+	let finalBench = [];
+	$: if(roster.players) {
+		finalBench = digestData(roster.players);
+	}
 	let finalIR = null;
 	if(roster.reserve) {
 		finalIR = digestData(roster.reserve, false, true);

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -5,4 +5,4 @@ available for your copy of League Page
 */
 
 // Keep in sync with package.json
-export const version = "1.0.4";
+export const version = "1.0.5";


### PR DESCRIPTION
Fixes a bug that occurs when rosters don't have players. Reported in issue https://github.com/nmelhado/league-page/issues/49.

Fix removes power rankings graph if no rosters have players and skips the bench step if the players field is null.