### PR TITLE
split projection call up to avoid overloading VERCEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.11] - 2021-09-09
+
+### Fixed
+
+- Pulling in the IDP projections overloaded Vercel's servers
+    - Split up the call into offensive and defensive projections and then combine them afterwards
+
 ## [1.0.10] - 2021-09-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "league-page",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "homepage": "https://github.com/nmelhado/league-page#readme",
   "author": {
     "name": "Nicholas Melhado",

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -5,4 +5,4 @@ available for your copy of League Page
 */
 
 // Keep in sync with package.json
-export const version = "1.0.10";
+export const version = "1.0.11";

--- a/src/routes/api/fetch_players_info.js
+++ b/src/routes/api/fetch_players_info.js
@@ -26,8 +26,16 @@ export async function get() {
     ];
 
     for(let week = 1; week <= fullSeasonLength + 3; week++) {
+        // offense
         resPromises.push(
-            fetch(`https://api.sleeper.app/projections/nfl/${year}/${week}?season_type=regular&position[]=DB&position[]=DEF&position[]=DL&position[]=FLEX&position[]=IDP_FLEX&position[]=K&position[]=LB&position[]=QB&position[]=RB&position[]=REC_FLEX&position[]=SUPER_FLEX&position[]=TE&position[]=WR&position[]=WRRB_FLEX&order_by=ppr`, {compress: true})
+            fetch(`https://api.sleeper.app/projections/nfl/${year}/${week}?season_type=regular&position[]=FLEX&position[]=K&position[]=QB&position[]=RB&position[]=REC_FLEX&position[]=SUPER_FLEX&position[]=TE&position[]=WR&position[]=WRRB_FLEX&order_by=ppr`, {compress: true})
+        );
+    }
+
+    for(let week = 1; week <= fullSeasonLength + 3; week++) {
+        // defense
+        resPromises.push(
+            fetch(`https://api.sleeper.app/projections/nfl/${year}/${week}?season_type=regular&position[]=DB&position[]=DEF&position[]=DL&position[]=IDP_FLEX&position[]=LB&order_by=ppr`, {compress: true})
         );
     }
 	
@@ -44,9 +52,16 @@ export async function get() {
         resJSONs.push(res.json());
     }
 
-    const weeklyData = await waitForAll(...resJSONs);
+    let weeklyData = await waitForAll(...resJSONs);
 
     const playerData = weeklyData.shift(); // first item is all player data, remaining items are weekly data for projections
+
+    const offset = weeklyData.length / 2; // number of weeks
+
+    for(let i = 0; i < offset; i++) {
+        weeklyData[i] = weeklyData[i].concat(weeklyData[i + offset]);
+    }
+    weeklyData = weeklyData.slice(0, offset);
 
     const scoringSettings = leagueData.scoring_settings;
         


### PR DESCRIPTION
Fix for issue https://github.com/nmelhado/league-page/issues/60.

Bug was introduced in pr https://github.com/nmelhado/league-page/pull/58. While the logic worked locally, the size of the call now exceeded the limits of Vercel's serverless functions.

Splitting up the call int offensive and defensive should circumvent this issue.