### PR TITLE
navigation bug fix and inactive player fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2021-09-11
+
+### Fixed
+
+- Bug with the nav bar that would occur when you don't have the blog enabled and visit any of the nested tabs
+- Bug with Inactive players breaking matchups and projections
+
 ## [1.1.0] - 2021-09-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "league-page",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/nmelhado/league-page#readme",
   "author": {
     "name": "Nicholas Melhado",

--- a/src/lib/Matchups/BracketsColumn.svelte
+++ b/src/lib/Matchups/BracketsColumn.svelte
@@ -114,7 +114,7 @@
         if(!starters) return 0;
         let totalPoints = 0;
         for(const starter of starters) {
-            totalPoints += parseFloat(players[starter].wi[playoffsStart - ix]?.p || 0);
+            totalPoints += parseFloat(players[starter].wi && players[starter].wi[playoffsStart - ix]?.p ? players[starter].wi[playoffsStart - ix].p : 0);
         }
         return round(totalPoints);
     }

--- a/src/lib/Matchups/Matchup.svelte
+++ b/src/lib/Matchups/Matchup.svelte
@@ -57,7 +57,7 @@
             const player = players[starter];
             let name = player.pos == "DEF" ? player.ln : `${player.fn[0]}. ${player.ln}`;
             let projection = 0;
-            if(player.wi[displayWeek]) {
+            if(player.wi && player.wi[displayWeek]) {
                 projection = parseFloat(player.wi[displayWeek].p);
             }
             return {
@@ -65,7 +65,7 @@
                 avatar: player.pos == "DEF" ? `background-image: url(https://sleepercdn.com/images/team_logos/nfl/${starter.toLowerCase()}.png)` : `background-image: url(https://sleepercdn.com/content/nfl/players/thumb/${starter}.jpg), url(https://sleepercdn.com/images/v2/icons/player_default.webp)`,
                 pos: player.pos,
                 team: player.t,
-                opponent: player.wi[displayWeek] ? player.wi[displayWeek].o : null,
+                opponent: player.wi && player.wi[displayWeek] ? player.wi[displayWeek].o : null,
                 projection,
                 points,
             };

--- a/src/lib/Nav/NavLarge.svelte
+++ b/src/lib/Nav/NavLarge.svelte
@@ -100,6 +100,10 @@
 	:global(.subText) {
 		font-size: 0.8em;
 	}
+
+	:global(.dontDisplay) {
+		display: none;
+	}
 </style>
 
 <div class="overlay" style="display: {display ? "block" : "none"};" on:click={() => open(true)} />
@@ -118,32 +122,29 @@
 				</Tab>
 			</div>
 		{:else}
-			{#if tab.label != 'Blog' || (tab.label == 'Blog' && enableBlog)}
-				<Tab
-					{tab}
-					on:touchstart={() => prefetch(tab.dest)}
-					on:mouseover={() => prefetch(tab.dest)}
-					on:click={() => goto(tab.dest)}
-					minWidth
-				>
-					<Icon class="material-icons">{tab.icon}</Icon>
-					<Label>{tab.label}</Label>
-				</Tab>
-			{/if}
+			<Tab
+				class="{tab.label == 'Blog' && !enableBlog ? 'dontDisplay' : ''}"
+				{tab}
+				on:touchstart={() => prefetch(tab.dest)}
+				on:mouseover={() => prefetch(tab.dest)}
+				on:click={() => goto(tab.dest)}
+				minWidth
+			>
+				<Icon class="material-icons">{tab.icon}</Icon>
+				<Label>{tab.label}</Label>
+			</Tab>
 		{/if}
 	</TabBar>
 	<div class="subMenu" style="max-height: {display ? 49 * tabChildren.length - 1 - (managers.length ? 0 : 48) : 0}px; width: {width}px; top: {height}px; left: {left}px; box-shadow: 0 0 {display ? "3px" : "0"} 0 #00316b; border: {display ? "1px" : "0"} solid #00316b; border-top: none;">
 		<List>
 			{#each tabChildren as subTab, ix}
 				{#if subTab.label == 'Managers'}
-					{#if managers.length}
-						<Item on:SMUI:action={() => subGoto(subTab.dest)} on:touchstart={() => prefetch(subTab.dest)} on:mouseover={() => prefetch(subTab.dest)}>
-							<Graphic class="material-icons">{subTab.icon}</Graphic>
-							<Text class="subText">{subTab.label}</Text>
-						</Item>
-						{#if ix != tabChildren.length - 1}
-							<Separator />
-						{/if}
+					<Item class="{managers.length ? '' : 'dontDisplay'}" on:SMUI:action={() => subGoto(subTab.dest)} on:touchstart={() => prefetch(subTab.dest)} on:mouseover={() => prefetch(subTab.dest)}>
+						<Graphic class="material-icons">{subTab.icon}</Graphic>
+						<Text class="subText">{subTab.label}</Text>
+					</Item>
+					{#if ix != tabChildren.length - 1}
+						<Separator />
 					{/if}
 				{:else}
 					<Item on:SMUI:action={() => subGoto(subTab.dest)} on:touchstart={() => {if(subTab.label != 'Go to Sleeper') prefetch(subTab.dest)}} on:mouseover={() => {if(subTab.label != 'Go to Sleeper') prefetch(subTab.dest)}}>

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -5,4 +5,4 @@ available for your copy of League Page
 */
 
 // Keep in sync with package.json
-export const version = "1.1.0";
+export const version = "1.1.1";

--- a/src/routes/api/fetch_players_info.js
+++ b/src/routes/api/fetch_players_info.js
@@ -70,11 +70,11 @@ const computePlayers = (playerData, weeklyData, scoringSettings) => {
             ln: projPlayer.last_name,
             pos: projPlayer.position,
         };
-        if(projPlayer.status != 'Inactive') {
+        if(projPlayer.team) {
             player.t = projPlayer.team;
             player.wi = {};
         }
-        if(projPlayer.status != 'Inactive' && projPlayer.injury_status) {
+        if(projPlayer.team && projPlayer.injury_status) {
             player.is = projPlayer.injury_status;
         }
 


### PR DESCRIPTION
This pr fixes two bugs:

- Bug with the nav bar that would occur when you don't have the blog enabled and visit any of the nested tabs
- Bug with Inactive players breaking matchups and projections