### PR TITLE
update resources icon to make it distinct from blog icon

### DIFF
--- a/src/lib/utils/tabs.js
+++ b/src/lib/utils/tabs.js
@@ -64,7 +64,7 @@ export const tabs = [
         ]
     },
     {
-        icon: 'feed',
+        icon: 'lightbulb',
         label: 'Resources',
         dest: '/resources',
     },


### PR DESCRIPTION
The two tabs (Resources and Blog) have very similar icons, this changes the resource icon to a lightbulb instead to differentiate the tabs better