### PR TITLE
Update awards to use the most recent league ID if it is completed.

### DIFF
--- a/src/lib/utils/leagueInfo.js
+++ b/src/lib/utils/leagueInfo.js
@@ -1,8 +1,8 @@
 /*   STEP 1   */
-export const leagueID = "your_league_id"; // your league ID
-export const leagueName = "your_league_name"; // your league name
+export const leagueID = "716721398717947904"; // your league ID
+export const leagueName = "Lathropolis"; // your league name
 export const dues = 100; // (optional) used in template constitution page
-export const dynasty = true; // true for dynasty leagues, false for redraft and keeper
+export const dynasty = false; // true for dynasty leagues, false for redraft and keeper
 export const enableBlog = false; // requires VITE_CONTENTFUL_ACCESS_TOKEN and VITE_CONTENTFUL_SPACE environment variables
 
 /*   STEP 2   */

--- a/src/lib/utils/leagueInfo.js
+++ b/src/lib/utils/leagueInfo.js
@@ -1,8 +1,8 @@
 /*   STEP 1   */
-export const leagueID = "716721398717947904"; // your league ID
-export const leagueName = "Lathropolis"; // your league name
+export const leagueID = "your_league_id"; // your league ID
+export const leagueName = "your_league_name"; // your league name
 export const dues = 100; // (optional) used in template constitution page
-export const dynasty = false; // true for dynasty leagues, false for redraft and keeper
+export const dynasty = true; // true for dynasty leagues, false for redraft and keeper
 export const enableBlog = false; // requires VITE_CONTENTFUL_ACCESS_TOKEN and VITE_CONTENTFUL_SPACE environment variables
 
 /*   STEP 2   */


### PR DESCRIPTION
closes #127 

If the current league status is "completed", use that league ID instead of the previous league ID when gathering awards.