### PR TITLE
fix rivalry bug and transaction search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.1] - 2023-04-30
+
+### Fixed
+
+- Fix the error thrown on the rivalry page when the pevious league ID is 0 [(issue #204)](https://github.com/nmelhado/league-page/issues/204)
+
+- Fix transaction search bar to debounce the ur change (focus was changing after every letter typed)
+
 ## [2.2.0] - 2023-04-17
 
 ### Added
@@ -12,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix rror thrown when no blog is present [(issue #202)](https://github.com/nmelhado/league-page/issues/202)
+- Fix error thrown when no blog is present [(issue #202)](https://github.com/nmelhado/league-page/issues/202)
     - Turn rosters into a map instead of an array in order to deliver the correct data
 
 ## [2.1.6] - 2023-04-15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "league-page",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "league-page",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@smui/button": "6.0.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "league-page",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "homepage": "https://github.com/nmelhado/league-page",
   "repository": {
     "type": "git",

--- a/src/lib/Transactions/TransactionsPage.svelte
+++ b/src/lib/Transactions/TransactionsPage.svelte
@@ -82,13 +82,23 @@
 
 	let lastUpdate = new Date;
 
+    let timer;
+
+	const debounce = (dest) => {
+		clearTimeout(timer);
+		timer = setTimeout(() => {
+            goto(dest,{noscroll: true,  keepfocus: true});
+		}, 750);
+	}
+
 	const search = () => {
 		lastUpdate = new Date;
 		query = query.trimLeft();
 		if(query.trim() == oldQuery) return;
 		page = 0;
 		if(postUpdate) {
-            goto(`/transactions?show=${show}&query=${query.trim()}&page=${page+1}`, {noscroll: true,  keepfocus: true});
+            const dest = `/transactions?show=${show}&query=${query.trim()}&page=${page+1}`;
+            debounce(dest);
 		}
 	}
 

--- a/src/lib/utils/helperFunctions/rivalryMatchups.js
+++ b/src/lib/utils/helperFunctions/rivalryMatchups.js
@@ -37,7 +37,7 @@ export const getRivalryMatchups = async (userOneID, userTwoID) => {
         matchups: []
     }
 
-    while(curLeagueID) {
+    while(curLeagueID && curLeagueID != 0) {
         const leagueData = await getLeagueData(curLeagueID).catch((err) => { console.error(err); });
         const year = leagueData.season;
         const rosterIDOne = getRosterIDFromManagerIDAndYear(teamManagers, userOneID, year);

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -5,4 +5,4 @@ available for your copy of League Page
 */
 
 // Keep in sync with package.json
-export const version = "2.2.0";
+export const version = "2.2.1";


### PR DESCRIPTION
Fix the rivalry bug where previous league ID = 0 and debounce to searches in the transaction bar