### PR TITLE
Fix Go to Sleeper link in Footer.svelte

### DIFF
--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -116,7 +116,11 @@
 					{#each tab.children as child}
                         <!-- Shouldn't show Managers tab unless managers has been populated -->
 				        {#if child.label != "Managers" || managers.length > 0}
-                            <li><div class="navLink" onclick={() => goto(child.dest)}>{child.label}</div></li>
+							{#if child.label == "Go to Sleeper"}
+								<li><div class="navLink" onclick={() => window.location = child.dest}>{child.label}</div></li>
+							{:else}
+                            	<li><div class="navLink" onclick={() => goto(child.dest)}>{child.label}</div></li>
+							{/if}
                         {/if}
 					{/each}
 				{/if}


### PR DESCRIPTION
Updated footer link to "Go to Sleeper". Link was broken since svelte restricted goto function to internal only. For external urls now recommended to use: window.location = url. Change for svelte documented [here](https://github.com/sveltejs/kit/pull/8837)